### PR TITLE
docs: update README.md and fix building instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ inevitable end? The leaderboard awaits the boldest shooters.🥇🥈🥉
 Clone the repository, then change your working directory to `build`:
    ```bash
    git clone https://github.com/ShingZhanho/ENGG1340-Project-25Spring
-   cd ENGG1340-Project-25Spring/build
+   cd ENGG1340-Project-25Spring
    git checkout v1.0.0
+   cd build
    ```
 `make` the target:
    ```bash


### PR DESCRIPTION
Currently, in `master` branch, there is no `build` folder under the project root folder.
Thus, following the instruction in the [doc](https://github.com/ShingZhanho/ENGG1340-Project-25Spring/blob/master/README.md#general-instructions) may lead to the unfounded directory error.
So, navigating to the project root folder and checking out to the `v1.0.0` tag should be done before navigating to the `build` folder.
The original one:
![original marked](https://github.com/user-attachments/assets/c6384e21-108e-4ece-a62f-d9264c35b46a)

The modified one:
![modified marked](https://github.com/user-attachments/assets/072f3178-8a69-4f6d-a265-888b957f4fd9)
